### PR TITLE
feat:productDetail추가

### DIFF
--- a/src/components/productItem/detail.tsx
+++ b/src/components/productItem/detail.tsx
@@ -1,0 +1,27 @@
+import { Product } from "../../types/types";
+
+const detail = ({
+  item: {
+    category,
+    title,
+    description,
+    image,
+    price,
+    rating: { rate },
+  },
+}: {
+  item: Product;
+}) => {
+  return (
+    <div className="product-item">
+      <p className="product-item__category">{category}</p>
+      <p className="product-item__title">{title}</p>
+      <p className="product-item__description">{description}</p>
+      <img className="product-item__image" src={image} />
+      <span className="product-item__price">{price}</span>
+      <span className="product-item__rating">{rate}</span>
+    </div>
+  );
+};
+
+export default detail;

--- a/src/components/productItem/index.tsx
+++ b/src/components/productItem/index.tsx
@@ -1,13 +1,16 @@
+import { Link } from "react-router-dom";
 import { Product } from "../../types/types";
 
-const ProductItem = ({ title, price, description, category, image, rating }: Product) => {
+const ProductItem = ({ id, title, price, category, image, rating }: Product) => {
   return (
     <li className="product-item">
-      <p className="product-item__category">{category}</p>
-      <p className="product-item__title">{title}</p>
-      <img className="product-item__image" src={image} />
-      <span className="product-item__price">{price}</span>
-      <span className="product-item__rating">{rating.rate}</span>
+      <Link to={`/products/${id}`}>
+        <p className="product-item__category">{category}</p>
+        <p className="product-item__title">{title}</p>
+        <img className="product-item__image" src={image} />
+        <span className="product-item__price">{price}</span>
+        <span className="product-item__rating">{rating.rate}</span>
+      </Link>
     </li>
   );
 };

--- a/src/pages/api/fetcher.ts
+++ b/src/pages/api/fetcher.ts
@@ -14,7 +14,7 @@ export const fetcher = async ({
   params?: AnyObj;
 }) => {
   try {
-    const url = `${BASE_URL}${path}`;
+    let url = `${BASE_URL}${path}`;
     const fetchOptions: RequestInit = {
       method,
       headers: {
@@ -22,6 +22,13 @@ export const fetcher = async ({
         "Access-Control-Allow-Origin": BASE_URL,
       },
     };
+    if (params) {
+      const searchParams = new URLSearchParams(params);
+      url += "?" + searchParams.toString();
+    }
+    if (body) {
+      fetchOptions.body = JSON.stringify(body);
+    }
     const response = await fetch(url, fetchOptions);
     const json = await response.json();
     return json;

--- a/src/pages/products/[id].tsx
+++ b/src/pages/products/[id].tsx
@@ -1,5 +1,25 @@
-const ProductDetail = () => {
-  return <div>ProductDetail</div>;
+import { useQuery } from "react-query";
+import { useParams } from "react-router-dom";
+import ProductDetail from "../../components/productItem/detail";
+import { QueryKeys, fetcher } from "../api/fetcher";
+import { Product } from "../../types/types";
+
+const ProductDetailPage = () => {
+  const { id } = useParams();
+  const { data } = useQuery<Product>([QueryKeys.PRODUCTS, id], () =>
+    fetcher({
+      method: "GET",
+      path: `/products/${id}`,
+    })
+  );
+  if (!data) return null;
+
+  return (
+    <div>
+      <h2>상품상세</h2>
+      <ProductDetail item={data} />;
+    </div>
+  );
 };
 
-export default ProductDetail;
+export default ProductDetailPage;

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -13,6 +13,7 @@ const ProductsList = () => {
 
   return (
     <div>
+      <h2>상품목록</h2>
       <ul className="products">
         {data?.map((product: Product) => (
           <ProductItem {...product} key={product.id} />

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,16 +1,21 @@
-import {
-  useQuery,
-  useMutation,
-  useQueryClient,
-  QueryClient,
-  QueryClientProvider,
-} from "react-query";
+import { QueryClient } from "react-query";
 
 // Create a client
 export const getClient = (() => {
   let client: QueryClient | null = null;
   return () => {
-    if (!client) client = new QueryClient({});
+    if (!client)
+      client = new QueryClient({
+        defaultOptions: {
+          queries: {
+            cacheTime: 1000 * 60 * 60 * 24,
+            staleTime: 1000 * 60,
+            refetchOnMount: false,
+            refetchOnReconnect: false,
+            refetchOnWindowFocus: false,
+          },
+        },
+      });
     return client;
   };
 })();


### PR DESCRIPTION
# 개발내용
* detail view 추가
* Queryclient cache 정책 추가
```javascript
client = new QueryClient({
        defaultOptions: {
          queries: {
            cacheTime: 1000 * 60 * 60 * 24,
            staleTime: 1000 * 60,
            refetchOnMount: false,
            refetchOnReconnect: false,
            refetchOnWindowFocus: false,
          },
        },
      });
```


# 개발화면

https://github.com/201steve/fake-shop/assets/79638133/543cec5f-8f5c-4e74-8787-cebdfdc5b7f5


# 알게된것
* cacheTime은 캐시된 데이터가 유효한 시간을 제어할 때 사용.
cacheTime에 설정한 시간 내에서는 inactive상태로 남아있다가 cacheTime이 지나면 inactive에서 빠진다. 그리고 fetch하면 새로 받아온다.
inactive에서 빠지기 전까지는 캐싱하고있는 데이터를 쓰는 것 같다. cache time은 설정된 시간동안 받아온 데이터를 유지시켰다가 네트워크 요청 없이 필요할 때 캐싱 한 데이터를 가져다 쓴다.

* staleTime은 데이터를 다시 패칭해야 할 필요가 있는지 판단하는데 사용. stale은 탁한, 이란뜻이고 반대개념은 fresh. 
fresh는 이제 막 패칭 한 신선한 데이터이고, staletime중에는 fresh상태가 유지되서 네트워크 요청을 최소화할 수 있다.
하지만 설정해둔 staleTime이 지나면 데이터는 fresh->stale로 변하고 서버의 데이터가 만약 업데이트 되어있다면 새로운 신선한 데이터를 받을 필요가 있다. 

* 목적별 옵션을 차등적용하는게 좋다.
* 주식이나, 채팅같은 실시간으로 fresh와 stale이 갱신되는 서비스의 경우 stale time이나 cacheTIme을 짧게 하거나
정적인 상품리스트의 경우 cacheTime을 조금 길게 해서 네트워크 요청을 최소화하고, 캐싱된 데이터를 사용하는게 좋다.